### PR TITLE
Support for object nesting

### DIFF
--- a/lib/sinatra_autoload/autoload.rb
+++ b/lib/sinatra_autoload/autoload.rb
@@ -1,5 +1,3 @@
-require 'singleton'
-
 module SinatraAutoload
   @@root_path = nil
 
@@ -13,11 +11,35 @@ module SinatraAutoload
 
   def self.directories(*args)
     return unless args
+
     args.each do |file_path|
-      Dir[ File.join( @root_path, file_path, '/**/*.rb') ].each do |file|
-        autoload File.basename(file, '.rb').classify.to_sym, file
+      Dir[ File.join(@@root_path, file_path, '/**/*.rb') ].each do |file|
+        names = object_names(file, file_path)
+        object_with_a_file_to_load = names.pop.to_sym
+
+        parent = preload_ancestors(names)
+        parent.autoload object_with_a_file_to_load, file
       end
     end
+  end
+
+  def self.preload_ancestors(names)
+    parent = Object
+    full_name = nil
+    names.each do |name|
+      begin
+        full_name = full_name ? "#{ full_name }::#{ name }" : name
+        parent = full_name.constantize
+      rescue NameError
+        parent.const_set name, (m = Module.new)
+        parent = m
+      end
+    end
+    parent
+  end
+
+  def self.object_names(file, path)
+    file.gsub("#{ File.join(@@root_path, path) }/", '').gsub('.rb', '').split('/').map(&:camelize)
   end
 
 end


### PR DESCRIPTION
Fixes nil error with variable `@root_path` that should be `@@root_path`
Add support for module and classes nesting in format `MyModule::MyClass`
